### PR TITLE
Kill the bird

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Here are a few problems with `travis_wait`:
 A janky Python script which executes any command and arguments passed to it, sending output directly to standard output
 and error, sending out the following message (by default) every nine minutes to rustle Travis' jimmies:
 
-> 🖕 travis pls 🖕
+> travis pls
 
 It works. Your builds will now stream your output back to you and will never, ever time out.
 

--- a/src/travispls/__init__.py
+++ b/src/travispls/__init__.py
@@ -61,7 +61,7 @@ def disturb():
     """Disturb standard error."""
     sys.stderr.write("{prefix}{message}{postfix}\n".format(
         prefix=AnsiColors.BOLD_YELLOW if AnsiColors.enabled() else "",
-        message="🖕 travis pls 🖕",
+        message="travis pls",
         postfix=AnsiColors.CLEAR if AnsiColors.enabled() else ""
     ))
 


### PR DESCRIPTION
I think this is clever and cool, but I think it would be better if it didn't say "fuck you" to a small group of people working for a non-vc-backed company that are doing their best to make a useful service. Without the 🖕 it's still amusing, just not mean anymore. 