### PR TITLE
Fix error when max timeout is 0

### DIFF
--- a/src/travispls/__init__.py
+++ b/src/travispls/__init__.py
@@ -38,6 +38,8 @@ def main():
 
     if args.max_timeout > 0:
         end_of_line = datetime.utcnow() + timedelta(seconds=args.max_timeout)
+    else:
+        end_of_line = None
 
     # start the process
     p = subprocess.Popen([args.command] + args.args)


### PR DESCRIPTION
Currently when the max timeout is 0 (no timeout) this tool throws an error after the first interval because the variable `end_of_line` was never initialized.

For example, when running `travis-pls -m 0 -i 1 sleep 10` the following error will occur after 1 second:
```
UnboundLocalError: local variable 'end_of_line' referenced before assignment
```

This PR fixes the problem by initializing `end_of_line` in all cases.